### PR TITLE
Could not build because of the PackageTargetFallback statement.

### DIFF
--- a/WordPressXF/WordPressXF/WordPressXF/WordPressXF.csproj
+++ b/WordPressXF/WordPressXF/WordPressXF/WordPressXF.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <PackageTargetFallback>$(PackageTargetFallback);portable-win+net45+wp8+win81+wpa8</PackageTargetFallback>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Removed the PackageTargetFallback statement. The project couldn't build because of this error:

error NU1003: PackageTargetFallback and AssetTargetFallback cannot be used together. Remove PackageTargetFallback(deprecated) references from the project environment.

Removed the statement to get it build for the netstandard2.0 target framework.
It now can build correctly.